### PR TITLE
Refactor authentication tests and add unit tests for user login

### DIFF
--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -1,0 +1,60 @@
+import pytest
+from cli.auth_cli import login_screen
+
+
+@pytest.fixture(autouse=True)
+def mock_usernames(mocker):
+    mocker.patch("cli.auth_cli.auth_service.get_all_usernames", return_value=["mario", "luigi"])
+
+
+def test_user_types_exit(mocker, capsys):
+    mocker.patch("builtins.input", return_value="esci")
+
+    result = login_screen()
+
+    assert result is None
+
+
+def test_login_success(mocker, capsys):
+    fake_user = mocker.MagicMock()
+    fake_user.full_name = "Mario Rossi"
+
+    mocker.patch("cli.auth_cli.auth_service.authenticate", return_value=fake_user)
+    mocker.patch("builtins.input", side_effect=["mario", "password123"])
+
+    result = login_screen()
+
+    assert result == fake_user
+    assert "Benvenuto/a, Mario Rossi" in capsys.readouterr().out
+
+
+def test_invalid_credentials_then_exit(mocker, capsys):
+    mocker.patch("cli.auth_cli.auth_service.authenticate", return_value=None)
+    mocker.patch("builtins.input", side_effect=["mario", "sbagliata", "esci"])
+
+    result = login_screen()
+
+    assert result is None
+    assert "Credenziali non valide" in capsys.readouterr().out
+
+
+def test_wrong_credentials_twice_then_login(mocker, capsys):
+    fake_user = mocker.MagicMock()
+    fake_user.full_name = "Luigi Verdi"
+
+    mocker.patch("cli.auth_cli.auth_service.authenticate", side_effect=[None, None, fake_user])
+    mocker.patch("builtins.input", side_effect=["x", "x", "x", "x", "luigi", "giusta"])
+
+    result = login_screen()
+
+    assert result == fake_user
+
+
+def test_available_users_are_displayed(mocker, capsys):
+    mocker.patch("builtins.input", return_value="esci")
+
+    login_screen()
+
+    output = capsys.readouterr().out
+    assert "mario" in output
+    assert "luigi" in output

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,48 +1,45 @@
 import sqlite3
 from unittest.mock import patch
-
 import pytest
-
 from services import auth_service
 
+@pytest.fixture
+def create_db():
+    def _create(users=None):
+        db = sqlite3.connect(":memory:")
+        db.row_factory = sqlite3.Row
+        db.execute(
+            """
+            CREATE TABLE users (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                username  TEXT    NOT NULL UNIQUE,
+                password  TEXT    NOT NULL,
+                full_name TEXT    NOT NULL
+            )
+            """
+        )
+        if users:
+            for u in users:
+                db.execute(
+                    "INSERT INTO users (username, password, full_name) VALUES (?, ?, ?)",
+                    (u["username"], u["password"], u["full_name"])
+                )
+        db.commit()
+        yield db
+        db.close()
+    return _create
 
 @pytest.fixture
-def conn():
-    db = sqlite3.connect(":memory:")
-    db.row_factory = sqlite3.Row
-    db.execute(
-        """
-        CREATE TABLE users (
-            id        INTEGER PRIMARY KEY AUTOINCREMENT,
-            username  TEXT    NOT NULL UNIQUE,
-            password  TEXT    NOT NULL,
-            full_name TEXT    NOT NULL
-        )
-        """
-    )
-    db.execute("INSERT INTO users (username, password, full_name) VALUES ('mario', 'pass1', 'Mario Rossi')")
-    db.execute("INSERT INTO users (username, password, full_name) VALUES ('laura', 'pass2', 'Laura Bianchi')")
-    db.commit()
-    return db
-
+def conn(create_db):
+    users = [
+        {"username": "mario", "password": "pass1", "full_name": "Mario Rossi"},
+        {"username": "laura", "password": "pass2", "full_name": "Laura Bianchi"}
+    ]
+    yield from create_db(users)
 
 @pytest.fixture
-def empty_conn():
-    db = sqlite3.connect(":memory:")
-    db.row_factory = sqlite3.Row
-    db.execute(
-        """
-        CREATE TABLE users (
-            id        INTEGER PRIMARY KEY AUTOINCREMENT,
-            username  TEXT    NOT NULL UNIQUE,
-            password  TEXT    NOT NULL,
-            full_name TEXT    NOT NULL
-        )
-        """
-    )
-    db.commit()
-    return db
-
+def empty_conn(create_db):
+    yield from create_db([])
 
 def test_authenticate_success(conn):
     with patch("services.auth_service.get_connection", return_value=conn):
@@ -51,24 +48,20 @@ def test_authenticate_success(conn):
     assert user.username == "mario"
     assert user.full_name == "Mario Rossi"
 
-
 def test_authenticate_wrong_password(conn):
     with patch("services.auth_service.get_connection", return_value=conn):
         user = auth_service.authenticate("mario", "wrong")
     assert user is None
-
 
 def test_authenticate_unknown_user(conn):
     with patch("services.auth_service.get_connection", return_value=conn):
         user = auth_service.authenticate("ghost", "pass1")
     assert user is None
 
-
 def test_get_all_usernames_returns_sorted_list(conn):
     with patch("services.auth_service.get_connection", return_value=conn):
         usernames = auth_service.get_all_usernames()
     assert usernames == ["laura", "mario"]
-
 
 def test_get_all_usernames_empty_table(empty_conn):
     with patch("services.auth_service.get_connection", return_value=empty_conn):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,44 @@
+import pytest
+import sqlite3
+import db.connection as db_connection
+
+
+@pytest.fixture(autouse=True)
+def reset_connection():
+    if db_connection._connection is not None:
+        db_connection._connection.close()
+    db_connection._connection = None
+    yield
+    db_connection.close_connection()
+
+
+def test_get_connection_returns_sqlite_connection(tmp_path, mocker):
+    mocker.patch("db.connection.DB_PATH", str(tmp_path / "test.db"))
+    conn = db_connection.get_connection()
+    assert isinstance(conn, sqlite3.Connection)
+
+
+def test_get_connection_singleton(tmp_path, mocker):
+    mocker.patch("db.connection.DB_PATH", str(tmp_path / "test.db"))
+    conn1 = db_connection.get_connection()
+    conn2 = db_connection.get_connection()
+    assert conn1 is conn2
+
+
+def test_get_connection_row_factory(tmp_path, mocker):
+    mocker.patch("db.connection.DB_PATH", str(tmp_path / "test.db"))
+    conn = db_connection.get_connection()
+    assert conn.row_factory == sqlite3.Row
+
+
+def test_close_connection(tmp_path, mocker):
+    mocker.patch("db.connection.DB_PATH", str(tmp_path / "test.db"))
+    db_connection.get_connection()
+    db_connection.close_connection()
+    assert db_connection._connection is None
+
+
+def test_close_connection_when_none():
+    db_connection._connection = None
+    db_connection.close_connection()
+    assert db_connection._connection is None

--- a/tests/test_reservation_cli.py
+++ b/tests/test_reservation_cli.py
@@ -6,35 +6,43 @@ from cli.reservation_cli import reserve_book_menu, my_reservations_menu
 FAKE_USER = User(id=1, username="giuseppe", password="hash", full_name="Giuseppe Russo")
 
 
+@pytest.fixture
+def mock_book(mocker):
+    book = mocker.Mock()
+    book.is_available = True
+    book.title = "Dune"
+    book.__str__ = mocker.Mock(return_value="[1] Dune - Frank Herbert")
+    return book
+
+
+@pytest.fixture
+def mock_reservation(mocker):
+    res = mocker.Mock()
+    res.is_active = True
+    return res
+
+
 # --- reserve_book_menu ---
 
-# Verifico che la funzione stampi un messaggio e esca se non ci sono libri disponibili
-def test_reserve_book_menu_no_books(mocker, capsys):
+def test_no_books_available(mocker, capsys):
     mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[])
 
     reserve_book_menu(FAKE_USER)
 
-    captured = capsys.readouterr()
-    assert "Nessun libro disponibile" in captured.out
+    assert "Nessun libro disponibile" in capsys.readouterr().out
 
 
-# Verifico che la funzione gestisca un input non numerico senza crashare
-def test_reserve_book_menu_invalid_input(mocker, capsys):
-    fake_book = mocker.Mock()
-    fake_book.__str__ = mocker.Mock(return_value="[1] Python - Guido")
-    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[fake_book])
+def test_invalid_input(mocker, capsys, mock_book):
+    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[mock_book])
     mocker.patch("builtins.input", return_value="abc")
 
     reserve_book_menu(FAKE_USER)
 
-    captured = capsys.readouterr()
-    assert "Input non valido" in captured.out
+    assert "Input non valido" in capsys.readouterr().out
 
 
-# Verifico che la funzione esca senza prenotare se l'utente inserisce 0
-def test_reserve_book_menu_cancel_with_zero(mocker):
-    fake_book = mocker.Mock()
-    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[fake_book])
+def test_user_cancels_with_zero(mocker, mock_book):
+    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[mock_book])
     mocker.patch("builtins.input", return_value="0")
     mock_reserve = mocker.patch("cli.reservation_cli.reservation_service.reserve_book")
 
@@ -43,89 +51,63 @@ def test_reserve_book_menu_cancel_with_zero(mocker):
     mock_reserve.assert_not_called()
 
 
-# Verifico che la funzione stampi un errore se il libro non esiste
-def test_reserve_book_menu_book_not_found(mocker, capsys):
-    fake_book = mocker.Mock()
-    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[fake_book])
-    mocker.patch("builtins.input", return_value="99")
+def test_book_not_found(mocker, capsys, mock_book):
+    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[mock_book])
     mocker.patch("cli.reservation_cli.book_service.get_book_by_id", return_value=None)
+    mocker.patch("builtins.input", return_value="99")
 
     reserve_book_menu(FAKE_USER)
 
-    captured = capsys.readouterr()
-    assert "Libro non disponibile" in captured.out
+    assert "Libro non disponibile" in capsys.readouterr().out
 
 
-# Verifico che la funzione stampi un errore se il libro non è disponibile
-def test_reserve_book_menu_book_not_available(mocker, capsys):
-    fake_book = mocker.Mock()
-    fake_book.is_available = False
-    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[fake_book])
+def test_book_not_available(mocker, capsys, mock_book):
+    mock_book.is_available = False
+    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[mock_book])
+    mocker.patch("cli.reservation_cli.book_service.get_book_by_id", return_value=mock_book)
     mocker.patch("builtins.input", return_value="1")
-    mocker.patch("cli.reservation_cli.book_service.get_book_by_id", return_value=fake_book)
 
     reserve_book_menu(FAKE_USER)
 
-    captured = capsys.readouterr()
-    assert "Libro non disponibile" in captured.out
+    assert "Libro non disponibile" in capsys.readouterr().out
 
 
-# Verifico che la funzione esca senza prenotare se l'utente non conferma
-def test_reserve_book_menu_user_does_not_confirm(mocker, capsys):
-    fake_book = mocker.Mock()
-    fake_book.is_available = True
-    fake_book.title = "Python"
-    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[fake_book])
-    mocker.patch("cli.reservation_cli.book_service.get_book_by_id", return_value=fake_book)
+def test_user_declines_confirmation(mocker, capsys, mock_book):
+    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[mock_book])
+    mocker.patch("cli.reservation_cli.book_service.get_book_by_id", return_value=mock_book)
     mocker.patch("builtins.input", side_effect=["1", "n"])
     mock_reserve = mocker.patch("cli.reservation_cli.reservation_service.reserve_book")
 
     reserve_book_menu(FAKE_USER)
 
     mock_reserve.assert_not_called()
-    captured = capsys.readouterr()
-    assert "annullata" in captured.out
+    assert "annullata" in capsys.readouterr().out
 
 
-# Verifico che la funzione chiami reserve_book e stampi il messaggio di conferma
-def test_reserve_book_menu_success(mocker, capsys):
-    fake_book = mocker.Mock()
-    fake_book.is_available = True
-    fake_book.title = "Python"
-    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[fake_book])
-    mocker.patch("cli.reservation_cli.book_service.get_book_by_id", return_value=fake_book)
+def test_reservation_success(mocker, capsys, mock_book):
+    mocker.patch("cli.reservation_cli.book_service.get_available_books", return_value=[mock_book])
+    mocker.patch("cli.reservation_cli.book_service.get_book_by_id", return_value=mock_book)
+    mocker.patch("cli.reservation_cli.reservation_service.reserve_book", return_value=(True, "Prenotazione confermata"))
     mocker.patch("builtins.input", side_effect=["1", "s"])
-    mocker.patch(
-        "cli.reservation_cli.reservation_service.reserve_book",
-        return_value=(True, "Prenotazione confermata"),
-    )
 
     reserve_book_menu(FAKE_USER)
 
-    captured = capsys.readouterr()
-    assert "Prenotazione confermata" in captured.out
+    assert "Prenotazione confermata" in capsys.readouterr().out
 
 
 # --- my_reservations_menu ---
 
-# Verifico che la funzione stampi un messaggio se l'utente non ha prenotazioni
-def test_my_reservations_menu_no_reservations(mocker, capsys):
+def test_no_reservations(mocker, capsys):
     mocker.patch("cli.reservation_cli.reservation_service.get_user_reservations", return_value=[])
 
     my_reservations_menu(FAKE_USER)
 
-    captured = capsys.readouterr()
-    assert "Non hai prenotazioni" in captured.out
+    assert "Non hai prenotazioni" in capsys.readouterr().out
 
 
-# Verifico che la funzione non chieda la cancellazione se non ci sono prenotazioni attive
-def test_my_reservations_menu_no_active_reservations(mocker):
-    fake_res = mocker.Mock()
-    fake_res.is_active = False
-    mocker.patch(
-        "cli.reservation_cli.reservation_service.get_user_reservations",
-        return_value=[fake_res],
-    )
+def test_all_reservations_inactive(mocker, mock_reservation):
+    mock_reservation.is_active = False
+    mocker.patch("cli.reservation_cli.reservation_service.get_user_reservations", return_value=[mock_reservation])
     mock_input = mocker.patch("builtins.input")
 
     my_reservations_menu(FAKE_USER)
@@ -133,14 +115,8 @@ def test_my_reservations_menu_no_active_reservations(mocker):
     mock_input.assert_not_called()
 
 
-# Verifico che la funzione esca senza cancellare se l'utente inserisce 0
-def test_my_reservations_menu_cancel_with_zero(mocker):
-    fake_res = mocker.Mock()
-    fake_res.is_active = True
-    mocker.patch(
-        "cli.reservation_cli.reservation_service.get_user_reservations",
-        return_value=[fake_res],
-    )
+def test_user_enters_zero_to_go_back(mocker, mock_reservation):
+    mocker.patch("cli.reservation_cli.reservation_service.get_user_reservations", return_value=[mock_reservation])
     mocker.patch("builtins.input", return_value="0")
     mock_cancel = mocker.patch("cli.reservation_cli.reservation_service.cancel_reservation")
 
@@ -149,14 +125,8 @@ def test_my_reservations_menu_cancel_with_zero(mocker):
     mock_cancel.assert_not_called()
 
 
-# Verifico che la funzione esca senza cancellare se l'utente inserisce un valore non numerico
-def test_my_reservations_menu_invalid_cancel_input(mocker):
-    fake_res = mocker.Mock()
-    fake_res.is_active = True
-    mocker.patch(
-        "cli.reservation_cli.reservation_service.get_user_reservations",
-        return_value=[fake_res],
-    )
+def test_invalid_cancel_input(mocker, mock_reservation):
+    mocker.patch("cli.reservation_cli.reservation_service.get_user_reservations", return_value=[mock_reservation])
     mocker.patch("builtins.input", return_value="abc")
     mock_cancel = mocker.patch("cli.reservation_cli.reservation_service.cancel_reservation")
 
@@ -165,21 +135,11 @@ def test_my_reservations_menu_invalid_cancel_input(mocker):
     mock_cancel.assert_not_called()
 
 
-# Verifico che la funzione chiami cancel_reservation e stampi il messaggio di risposta
-def test_my_reservations_menu_cancel_success(mocker, capsys):
-    fake_res = mocker.Mock()
-    fake_res.is_active = True
-    mocker.patch(
-        "cli.reservation_cli.reservation_service.get_user_reservations",
-        return_value=[fake_res],
-    )
+def test_cancellation_success(mocker, capsys, mock_reservation):
+    mocker.patch("cli.reservation_cli.reservation_service.get_user_reservations", return_value=[mock_reservation])
+    mocker.patch("cli.reservation_cli.reservation_service.cancel_reservation", return_value=(True, "Prenotazione cancellata"))
     mocker.patch("builtins.input", return_value="1")
-    mocker.patch(
-        "cli.reservation_cli.reservation_service.cancel_reservation",
-        return_value=(True, "Prenotazione cancellata"),
-    )
 
     my_reservations_menu(FAKE_USER)
 
-    captured = capsys.readouterr()
-    assert "Prenotazione cancellata" in captured.out
+    assert "Prenotazione cancellata" in capsys.readouterr().out

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -1,0 +1,6 @@
+from models.user import User
+
+
+def test_user_str():
+    user = User(id=1, username="mario", password="secret", full_name="Mario Rossi")
+    assert str(user) == "Mario Rossi (@mario)"


### PR DESCRIPTION
## Summary
- Refactored `test_auth_service` and `test_reservation_cli` with shared fixtures, factory pattern, and cleaner structure
- Added new unit tests for `auth_cli` (login_screen), `db.connection` (singleton, row_factory, close), and `User` model

## Test plan
- [x] All existing tests pass after refactoring
- [x] New tests cover login flow, db connection lifecycle, and User.__str__
